### PR TITLE
🔧 CHORE 1) 캘린더 기본 세팅

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -8,6 +8,10 @@ module.exports = override(
     '@asset': path.resolve(__dirname, 'src/asset'),
     '@component': path.resolve(__dirname, 'src/component'),
     '@container': path.resolve(__dirname, 'src/container'),
+    '@features': path.resolve(__dirname, 'src/features'),
+    '@hooks': path.resolve(__dirname, 'src/hooks'),
+    '@routes': path.resolve(__dirname, 'src/routes'),
     '@styles': path.resolve(__dirname, 'src/styles'),
+    '@utils': path.resolve(__dirname, 'src/utils'),
   })
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,21 @@
         "@types/node": "^16.18.36",
         "@types/react": "^18.2.13",
         "@types/react-dom": "^18.2.6",
+        "date-fns": "^2.30.0",
+        "moment": "^2.29.4",
         "react": "^18.2.0",
+        "react-big-calendar": "^1.8.1",
+        "react-datepicker": "^4.14.1",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.10.0",
         "react-router-dom": "^6.13.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/react-big-calendar": "^1.6.4",
+        "@types/react-datepicker": "^4.11.2",
         "customize-cra": "^1.0.0",
         "react-app-rewired": "^2.2.1",
         "tailwindcss": "^3.3.2"
@@ -3255,12 +3262,32 @@
         }
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
       "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.9.tgz",
+      "integrity": "sha512-3BekqcwB6Umeya+16XPooARn4qEPW6vNvwYnlofIYe6h9qG1/VeD7UvShCWx11eFz5ELYmwIEshz+MkPX3wjcQ==",
+      "dependencies": {
+        "dequal": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3975,6 +4002,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/date-arithmetic": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/date-arithmetic/-/date-arithmetic-4.1.1.tgz",
+      "integrity": "sha512-o9ILUTMSRiOC73o7h30mgLpuDwOJWqMHZfnEIwNQlfZsGY6Kw2gK5Gz6nXAjNt9zm3Qpr12pM4FDqssfdtBzGA==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.40.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
@@ -4131,6 +4164,29 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-big-calendar": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@types/react-big-calendar/-/react-big-calendar-1.6.4.tgz",
+      "integrity": "sha512-xAbdQ2cQhx71dsnacJ1knSGqTi6cD8odGi28AzCjA+N4bgpJjSyYo/fN1bG4ScfBAEQomSl/UoXYrSgUoJ0MGA==",
+      "dev": true,
+      "dependencies": {
+        "@types/date-arithmetic": "*",
+        "@types/prop-types": "*",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-datepicker": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-4.11.2.tgz",
+      "integrity": "sha512-ELYyX3lb3K1WltqdlF1hbnaDGgzlF6PIR5T4W38cSEcfrQDIrPE+Ioq5pwRe/KEJ+ihHMjvTVZQkwJx0pWMNHQ==",
+      "dev": true,
+      "dependencies": {
+        "@popperjs/core": "^2.9.2",
+        "@types/react": "*",
+        "date-fns": "^2.0.1",
+        "react-popper": "^2.2.5"
+      }
+    },
     "node_modules/@types/react-dom": {
       "version": "18.2.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
@@ -4213,6 +4269,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.5",
@@ -5692,6 +5753,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
     "node_modules/clean-css": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
@@ -5719,6 +5785,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -6404,6 +6478,31 @@
         "node": ">=10"
       }
     },
+    "node_modules/date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
+      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ=="
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -6647,6 +6746,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -8489,6 +8597,11 @@
         "which": "bin/which"
       }
     },
+    "node_modules/globalize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-0.1.1.tgz",
+      "integrity": "sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA=="
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -9040,6 +9153,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -11763,6 +11884,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -11819,6 +11945,14 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -11890,6 +12024,11 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -12075,6 +12214,25 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -14213,6 +14371,50 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/react-big-calendar": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.8.1.tgz",
+      "integrity": "sha512-yEiScxReMrRCc0qFdZIKY/L6+argK4ZiYzLk5bck8CRYVbHjCCb/6Ictv42kPs/g3Q4RIb8+GUjDzk/uFtu76Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "clsx": "^1.2.1",
+        "date-arithmetic": "^4.1.0",
+        "dayjs": "^1.11.7",
+        "dom-helpers": "^5.2.1",
+        "globalize": "^0.1.1",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "luxon": "^3.2.1",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
+        "prop-types": "^15.8.1",
+        "react-overlays": "^5.2.1",
+        "uncontrollable": "^7.2.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17 || ^18",
+        "react-dom": "^16.14.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-datepicker": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.14.1.tgz",
+      "integrity": "sha512-uiPfjD+25KI5WOfCAXlzQgSLyksTagk3wwKn1KGBdF19YtybFDregRmcoNNGveQHAbT10SJZdCvk/8pbc7zxJg==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.2",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.24.0",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.12.2",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18",
+        "react-dom": "^16.9.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -14347,10 +14549,74 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.0.tgz",
+      "integrity": "sha512-SoBQp5sP2NgJgnzIoW/0foYRzuB/dlbfaFaFv7N5c7Mk+WvzAIKwvld7LTPLhRo+UQA5oCzdtm9h6oBKTbuKCA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-onclickoutside": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
+      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/react-onclickoutside/blob/master/FUNDING.md"
+      },
+      "peerDependencies": {
+        "react": "^15.5.x || ^16.x || ^17.x || ^18.x",
+        "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
+      }
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -16209,6 +16475,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -16419,6 +16699,14 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -19490,10 +19778,23 @@
         "source-map": "^0.7.3"
       }
     },
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+    },
     "@remix-run/router": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
       "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q=="
+    },
+    "@restart/hooks": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.9.tgz",
+      "integrity": "sha512-3BekqcwB6Umeya+16XPooARn4qEPW6vNvwYnlofIYe6h9qG1/VeD7UvShCWx11eFz5ELYmwIEshz+MkPX3wjcQ==",
+      "requires": {
+        "dequal": "^2.0.2"
+      }
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -19998,6 +20299,12 @@
         "@types/node": "*"
       }
     },
+    "@types/date-arithmetic": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/date-arithmetic/-/date-arithmetic-4.1.1.tgz",
+      "integrity": "sha512-o9ILUTMSRiOC73o7h30mgLpuDwOJWqMHZfnEIwNQlfZsGY6Kw2gK5Gz6nXAjNt9zm3Qpr12pM4FDqssfdtBzGA==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "8.40.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
@@ -20154,6 +20461,29 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-big-calendar": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@types/react-big-calendar/-/react-big-calendar-1.6.4.tgz",
+      "integrity": "sha512-xAbdQ2cQhx71dsnacJ1knSGqTi6cD8odGi28AzCjA+N4bgpJjSyYo/fN1bG4ScfBAEQomSl/UoXYrSgUoJ0MGA==",
+      "dev": true,
+      "requires": {
+        "@types/date-arithmetic": "*",
+        "@types/prop-types": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-datepicker": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-4.11.2.tgz",
+      "integrity": "sha512-ELYyX3lb3K1WltqdlF1hbnaDGgzlF6PIR5T4W38cSEcfrQDIrPE+Ioq5pwRe/KEJ+ihHMjvTVZQkwJx0pWMNHQ==",
+      "dev": true,
+      "requires": {
+        "@popperjs/core": "^2.9.2",
+        "@types/react": "*",
+        "date-fns": "^2.0.1",
+        "react-popper": "^2.2.5"
+      }
+    },
     "@types/react-dom": {
       "version": "18.2.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
@@ -20236,6 +20566,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+    },
+    "@types/warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
     },
     "@types/ws": {
       "version": "8.5.5",
@@ -21306,6 +21641,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
     "clean-css": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
@@ -21330,6 +21670,11 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "co": {
       "version": "4.6.0",
@@ -21818,6 +22163,24 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg=="
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
+    },
+    "dayjs": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
+      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ=="
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -22002,6 +22365,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "dom-serializer": {
@@ -23346,6 +23718,11 @@
         }
       }
     },
+    "globalize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-0.1.1.tgz",
+      "integrity": "sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA=="
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -23734,6 +24111,14 @@
         "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "ipaddr.js": {
@@ -25694,6 +26079,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -25749,6 +26139,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
+    },
     "lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -25802,6 +26197,11 @@
       "requires": {
         "fs-monkey": "^1.0.4"
       }
+    },
+    "memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -25929,6 +26329,19 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "requires": {
         "minimist": "^1.2.6"
+      }
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
+    "moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "requires": {
+        "moment": "^2.29.4"
       }
     },
     "ms": {
@@ -27281,6 +27694,42 @@
         }
       }
     },
+    "react-big-calendar": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.8.1.tgz",
+      "integrity": "sha512-yEiScxReMrRCc0qFdZIKY/L6+argK4ZiYzLk5bck8CRYVbHjCCb/6Ictv42kPs/g3Q4RIb8+GUjDzk/uFtu76Q==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "clsx": "^1.2.1",
+        "date-arithmetic": "^4.1.0",
+        "dayjs": "^1.11.7",
+        "dom-helpers": "^5.2.1",
+        "globalize": "^0.1.1",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "luxon": "^3.2.1",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
+        "prop-types": "^15.8.1",
+        "react-overlays": "^5.2.1",
+        "uncontrollable": "^7.2.1"
+      }
+    },
+    "react-datepicker": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.14.1.tgz",
+      "integrity": "sha512-uiPfjD+25KI5WOfCAXlzQgSLyksTagk3wwKn1KGBdF19YtybFDregRmcoNNGveQHAbT10SJZdCvk/8pbc7zxJg==",
+      "requires": {
+        "@popperjs/core": "^2.9.2",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.24.0",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.12.2",
+        "react-popper": "^2.3.0"
+      }
+    },
     "react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -27381,10 +27830,56 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "react-icons": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.0.tgz",
+      "integrity": "sha512-SoBQp5sP2NgJgnzIoW/0foYRzuB/dlbfaFaFv7N5c7Mk+WvzAIKwvld7LTPLhRo+UQA5oCzdtm9h6oBKTbuKCA==",
+      "requires": {}
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-onclickoutside": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
+      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
+      "requires": {}
+    },
+    "react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "requires": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      }
+    },
+    "react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "requires": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      }
     },
     "react-refresh": {
       "version": "0.11.0",
@@ -28752,6 +29247,17 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -28898,6 +29404,14 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-calendar-app",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.9.5",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -22,6 +23,7 @@
         "react-datepicker": "^4.14.1",
         "react-dom": "^18.2.0",
         "react-icons": "^4.10.0",
+        "react-redux": "^8.1.1",
         "react-router-dom": "^6.13.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
@@ -31,6 +33,9 @@
         "@types/react-big-calendar": "^1.6.4",
         "@types/react-datepicker": "^4.11.2",
         "customize-cra": "^1.0.0",
+        "eslint": "^8.43.0",
+        "eslint-config-prettier": "^8.8.0",
+        "prettier": "^2.8.8",
         "react-app-rewired": "^2.2.1",
         "tailwindcss": "^3.3.2"
       }
@@ -3271,6 +3276,29 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
+      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
+      "dependencies": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
@@ -4061,6 +4089,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -4269,6 +4306,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -7212,6 +7254,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -8774,6 +8828,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -14099,6 +14166,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -14618,6 +14700,49 @@
         "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.1.tgz",
+      "integrity": "sha512-5W0QaKtEhj+3bC0Nj0NkqkhIv8gLADH/2kYFMTHxCVqQILiWzLv6MaLuV5wJU3BQEdHKzTfcvPN0WMS6SC1oyA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -14783,6 +14908,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -14908,6 +15049,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -16610,6 +16756,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -19783,6 +19937,17 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
+    "@reduxjs/toolkit": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
+      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
+      "requires": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      }
+    },
     "@remix-run/router": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
@@ -20358,6 +20523,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -20566,6 +20740,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -22803,6 +22982,13 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -23838,6 +24024,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -27490,6 +27691,12 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
+    "prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -27881,6 +28088,26 @@
         "warning": "^4.0.2"
       }
     },
+    "react-redux": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.1.tgz",
+      "integrity": "sha512-5W0QaKtEhj+3bC0Nj0NkqkhIv8gLADH/2kYFMTHxCVqQILiWzLv6MaLuV5wJU3BQEdHKzTfcvPN0WMS6SC1oyA==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -28001,6 +28228,20 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "requires": {}
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -28101,6 +28342,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "resolve": {
       "version": "1.22.2",
@@ -29335,6 +29581,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^18.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.10.0",
     "react-router-dom": "^6.13.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "@types/react-big-calendar": "^1.6.4",
     "@types/react-datepicker": "^4.11.2",
     "customize-cra": "^1.0.0",
+    "eslint": "^8.43.0",
+    "eslint-config-prettier": "^8.8.0",
+    "prettier": "^2.8.8",
     "react-app-rewired": "^2.2.1",
     "tailwindcss": "^3.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.2.13",
     "@types/react-dom": "^18.2.6",
     "react": "^18.2.0",
+    "react-datepicker": "^4.14.1",
     "react-dom": "^18.2.0",
     "react-icons": "^4.10.0",
     "react-router-dom": "^6.13.0",
@@ -43,6 +44,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react-datepicker": "^4.11.2",
     "customize-cra": "^1.0.0",
     "react-app-rewired": "^2.2.1",
     "tailwindcss": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -17,6 +18,7 @@
     "react-datepicker": "^4.14.1",
     "react-dom": "^18.2.0",
     "react-icons": "^4.10.0",
+    "react-redux": "^8.1.1",
     "react-router-dom": "^6.13.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.2.13",
     "@types/react-dom": "^18.2.6",
     "react": "^18.2.0",
+    "react-big-calendar": "^1.8.1",
     "react-datepicker": "^4.14.1",
     "react-dom": "^18.2.0",
     "react-icons": "^4.10.0",
@@ -44,6 +45,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react-big-calendar": "^1.6.4",
     "@types/react-datepicker": "^4.11.2",
     "customize-cra": "^1.0.0",
     "react-app-rewired": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@types/node": "^16.18.36",
     "@types/react": "^18.2.13",
     "@types/react-dom": "^18.2.6",
+    "date-fns": "^2.30.0",
+    "moment": "^2.29.4",
     "react": "^18.2.0",
     "react-big-calendar": "^1.8.1",
     "react-datepicker": "^4.14.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
+import { Provider } from 'react-redux';
+import { store } from './store';
+
 import Main from '@container/Main';
 import MainCalendar from '@/component/Main/MainCalendar';
 import ErrorPage from '@container/ErrorPage';
@@ -21,7 +24,9 @@ const router = createBrowserRouter([
 
 function App() {
   return (
-    <RouterProvider router={router} />
+    <Provider store={store}>
+      <RouterProvider router={router} />
+    </Provider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
-import Calendar from '@container/Calendar';
+import Main from '@container/Main';
+import MainCalendar from '@/component/Main/MainCalendar';
 import ErrorPage from '@container/ErrorPage';
 
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <Calendar />,
+    element: <Main />,
     errorElement: <ErrorPage />,
+    children: [
+      {
+        path: "/month",
+        element: <MainCalendar />,
+      },
+    ]
   },
 ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ const router = createBrowserRouter([
     errorElement: <ErrorPage />,
     children: [
       {
-        path: "/month",
+        path: "/:drilldownView/:year/:month/:date",
         element: <MainCalendar />,
       },
     ]

--- a/src/component/Main/Aside.tsx
+++ b/src/component/Main/Aside.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+function Aside() {
+    return (
+        <div className="w-14 h-full border-l">
+
+        </div>
+    )
+}
+
+export default Aside;

--- a/src/component/Main/Gnb.tsx
+++ b/src/component/Main/Gnb.tsx
@@ -2,12 +2,22 @@ import React from "react";
 import { BiMenu, BiChevronRight, BiChevronLeft } from 'react-icons/bi';
 import { HiOutlineSearch } from 'react-icons/hi';
 
+import { useAppDispatch, useAppSelector } from '@hooks/reduxWithType';
+import { changeViewDate, changeDrilldownView } from '@features/mainSlice';
+
 import Spacing from "@component/common/Spacing";
 
 import Calendar from "@asset/calendar.png";
 import UserProfile from "@asset/user-profile.png";
 
+import { getViewDateObj, getMomentFromViewDate } from "@utils/formattingDate";
+
+import moment from "moment";
+
 function Gnb() {
+    const { viewDate, drilldownView } = useAppSelector((state) => state.main);
+    const dispatch = useAppDispatch();
+
     const GNBLeft = () => {
         return (
             <>
@@ -35,34 +45,63 @@ function Gnb() {
     const ChangeMonthBtns = () => {
         return (
             <div className="flex items-center">
-                <button className="border rounded px-3.5 py-1.5 border-slate-300">
+                <button
+                    onClick={() => dispatch(changeViewDate(getViewDateObj(moment().format())))}
+                    className="border rounded px-3.5 py-1.5 border-slate-300"
+                >
                     <span className="text-sm">오늘</span>
                 </button>
                 <Spacing space="mr-2"/>
-                <button className="px-1">
+                <button
+                    className="px-1"
+                    onClick={() => {
+                        const momentDate = getMomentFromViewDate(viewDate);
+                        const prevMonth = momentDate.subtract(1, 'month').startOf('month').format();
+                        dispatch(changeViewDate(getViewDateObj(prevMonth)));
+                    }}
+                >
                     <BiChevronLeft size="1.5rem" title="전 달"/>
                 </button>
-                <button className="px-1">
+                <button
+                    className="px-1"
+                    onClick={() => {
+                        const momentDate = getMomentFromViewDate(viewDate);
+                        const nextMonth = momentDate.add(1, 'month').startOf('month').format();
+                        dispatch(changeViewDate(getViewDateObj(nextMonth)));
+                    }}
+                >
                     <BiChevronRight size="1.5rem" title="다음 달" />
                 </button>
                 <Spacing space="mr-2"/>
-                <span className="text-xl">2023년 6월</span>
+                <span className="text-xl">{`${viewDate.year}년 ${viewDate.month}월`}</span>
             </div>
         )
     }
 
     const ChangeCriteriaBtn = () => {
+        const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+            const { value } = e.currentTarget;
+
+            if (value === 'month' || value === 'week' || value === 'day') {
+                dispatch(changeDrilldownView(value));
+            }
+        }
+
         return (
             <div className="flex items-center">
                 <button>
                     <HiOutlineSearch />
                 </button>
                 <Spacing space="mr-3"/>
-                {/* TODO */}
-                <select defaultValue="월" className="border rounded px-3 py-1 border-slate-300 font-sm">
-                    <option value="월">월</option>
-                    <option value="주">주</option>
-                    <option value="일">일</option>
+                {/* TODO CSS */}
+                <select
+                    className="border rounded px-3 py-1 border-slate-300 font-sm"
+                    onChange={handleSelect}
+                    value={drilldownView || 'month'}
+                >
+                    <option value="month">월</option>
+                    <option value="week">주</option>
+                    <option value="day">일</option>
                 </select>
             </div>
         )

--- a/src/component/Main/Gnb.tsx
+++ b/src/component/Main/Gnb.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { BiMenu, BiChevronRight, BiChevronLeft } from 'react-icons/bi';
+import { HiOutlineSearch } from 'react-icons/hi';
+
+import Spacing from "@component/common/Spacing";
+
+import Calendar from "@asset/calendar.png";
+import UserProfile from "@asset/user-profile.png";
+
+function Gnb() {
+    const GNBLeft = () => {
+        return (
+            <>
+                <button className="p-3">
+                    <BiMenu size="1.5rem" />
+                </button>
+                <div className="w-7 h-7">
+                    <img src={Calendar} alt="" />
+                </div>
+                <div className="px-3">
+                    <span className="text-xl">캘린더</span>
+                </div>
+            </>
+        )
+    }
+
+    const GNBRight = () => {
+        return (
+            <div className="w-10 h-10 rounded-full overflow-hidden hover:bg-neutral-200">
+                <img src={UserProfile} alt="" />
+            </div>
+        )
+    }
+
+    const ChangeMonthBtns = () => {
+        return (
+            <div className="flex items-center">
+                <button className="border rounded px-3.5 py-1.5 border-slate-300">
+                    <span className="text-sm">오늘</span>
+                </button>
+                <Spacing space="mr-2"/>
+                <button className="px-1">
+                    <BiChevronLeft size="1.5rem" title="전 달"/>
+                </button>
+                <button className="px-1">
+                    <BiChevronRight size="1.5rem" title="다음 달" />
+                </button>
+                <Spacing space="mr-2"/>
+                <span className="text-xl">2023년 6월</span>
+            </div>
+        )
+    }
+
+    const ChangeCriteriaBtn = () => {
+        return (
+            <div className="flex items-center">
+                <button>
+                    <HiOutlineSearch />
+                </button>
+                <Spacing space="mr-3"/>
+                {/* TODO */}
+                <select defaultValue="월" className="border rounded px-3 py-1 border-slate-300 font-sm">
+                    <option value="월">월</option>
+                    <option value="주">주</option>
+                    <option value="일">일</option>
+                </select>
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex justify-between items-center w-full h-14 p-2 border-b">
+            <div className="flex items-center flex-none">
+                <GNBLeft />
+            </div>
+
+            <Spacing space="mr-14"/>
+
+            <div className="flex justify-between flex-1">
+                <ChangeMonthBtns />
+                <ChangeCriteriaBtn />
+            </div>
+
+            <Spacing space="ml-8"/>
+
+            <div className="flex items-center flex-none">
+                <GNBRight />
+            </div>
+        </div>
+    )
+}
+
+export default Gnb;

--- a/src/component/Main/MainCalendar.tsx
+++ b/src/component/Main/MainCalendar.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useCallback } from 'react';
+import { Calendar, momentLocalizer } from 'react-big-calendar'
+import moment from 'moment';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import '@styles/Main/customMainCalendar.css';
+
+moment.locale('ko-KR');
+const localizer = momentLocalizer(moment);
+
+interface IWeek {
+    [index: string]: string;
+    Sun: string;
+    Mon: string;
+    Tue: string;
+    Wed: string;
+    Thu: string;
+    Fri: string;
+    Sat: string;
+}
+
+interface IEvent {
+    allDay?: boolean | undefined;
+    title?: React.ReactNode | undefined;
+    start?: Date | undefined;
+    end?: Date | undefined;
+    resource?: any;
+}
+
+
+
+const events = [
+  {
+    id: 0,
+    allDay: false,
+    title: <p>Board meeting</p>,
+    start: new Date(2023, 5, 24, 9, 0, 0),
+    end: new Date(2023, 5, 24, 13, 0, 0),
+    resource: 1,
+  },
+  {
+    id: 1,
+    allDay: false,
+    title: <p>Board meeting</p>,
+    start: new Date(2023, 5, 23, 9, 0, 0),
+    end: new Date(2023, 5, 24, 9, 0, 0),
+    resource: 2,
+  },
+  {
+    id: 2,
+    allDay: false,
+    title: <p>Board meeting</p>,
+    start: new Date(2023, 5, 10, 9, 0, 0),
+    end: new Date(2023, 5, 11, 12, 0, 0),
+    resource: 3,
+  },
+  {
+    id: 11,
+    allDay: false,
+    title: <p>Board meeting</p>,
+    start: new Date(2023, 5, 29, 9, 0, 0),
+    end: new Date(2023, 5, 29, 12, 0, 0),
+    resource: 4,
+  },
+]
+
+function MainCalendar() {
+    const [myEvents, setEvents] = useState(events);
+
+    const handleSelectSlot = useCallback(
+      ({ start, end }: {start: Date, end: Date}) => {
+        const title = window.prompt('New Event name')
+        if (title) {
+          setEvents([...myEvents, { id: myEvents.length + 1, allDay: false, start, end, title: <p>{title}</p>, resource: myEvents.length + 1 }])
+        }
+      },
+      [setEvents]
+    )
+  
+    const handleSelectEvent = useCallback(
+      (event: IEvent) => window.alert(event.title),
+      []
+    )
+
+    const StyleNone = () => <></>;
+    const DateHeader = ({label, date}: {label: string, date: Date}) => {
+      const day = moment(date).format("M월 D일");
+      const isToday = moment().format("YYYYMD") === `${date.getFullYear()}${date.getMonth() + 1}${date.getDate()}`;
+
+      const DayElement = () => {
+        if (isToday) {
+          return (
+            <div className='bg-selected w-fit p-1 rounded-full cursor-pointer hover:bg-blue-600'>
+              <p className='text-xs text-center text-white font-normal'>{Number.parseInt(label)}</p>
+            </div>
+          )
+        }
+
+        return <p className='text-xs text-center cursor-pointer'>{label === '01' ? day : Number.parseInt(label)}</p>
+      }
+
+      return (
+        <DayElement />
+      )
+    };
+
+    const MonthHeader = ({label}: {label: string}) => {
+      const week: IWeek = {Sun: '일', Mon: '월', Tue: '화', Wed: '수', Thu: '목', Fri: '금', Sat: '토'};
+      return (
+        <p className='text-xs text-zinc-400'>{week[label] || ''}</p>
+      )
+    }
+
+    const EventElement = ({title}: {title: string}) => {
+      return (
+        <div>{title}</div>
+      )
+    }
+
+    return (
+      <div className='h-full'>
+          <Calendar
+            localizer={localizer}
+            startAccessor="start"
+            endAccessor="end"
+            events={myEvents}
+            selectable
+            onSelectEvent={handleSelectEvent}
+            onSelectSlot={handleSelectSlot}
+            components={{
+              toolbar: StyleNone,
+              dateCellWrapper: StyleNone,
+              month: {
+                header: MonthHeader,
+                dateHeader: DateHeader,
+                // event: EventElement,
+              }
+            }}
+          />
+      </div>
+    )
+}
+
+export default MainCalendar;

--- a/src/component/Main/MainCalendar.tsx
+++ b/src/component/Main/MainCalendar.tsx
@@ -26,40 +26,38 @@ interface IEvent {
     resource?: any;
 }
 
-
-
 const events = [
   {
     id: 0,
     allDay: false,
-    title: <p>Board meeting</p>,
+    title: <p>0Board meeting</p>,
     start: new Date(2023, 5, 24, 9, 0, 0),
     end: new Date(2023, 5, 24, 13, 0, 0),
-    resource: 1,
+    resource: 0,
   },
   {
     id: 1,
     allDay: false,
-    title: <p>Board meeting</p>,
+    title: <p>1Board meeting</p>,
     start: new Date(2023, 5, 23, 9, 0, 0),
     end: new Date(2023, 5, 24, 9, 0, 0),
-    resource: 2,
+    resource: 1,
   },
   {
     id: 2,
     allDay: false,
-    title: <p>Board meeting</p>,
+    title: <p>2Board meeting</p>,
     start: new Date(2023, 5, 10, 9, 0, 0),
     end: new Date(2023, 5, 11, 12, 0, 0),
-    resource: 3,
+    resource: 1,
   },
   {
     id: 11,
     allDay: false,
-    title: <p>Board meeting</p>,
-    start: new Date(2023, 5, 29, 9, 0, 0),
-    end: new Date(2023, 5, 29, 12, 0, 0),
-    resource: 4,
+    title: <p>3Board meeting</p>,
+    start: new Date(2023, 5, 29, 18, 0, 0),
+    end: new Date(2023, 5, 29, 19, 0, 0),
+    resource: 2,
   },
 ]
 

--- a/src/component/Main/MiniCalendar.tsx
+++ b/src/component/Main/MiniCalendar.tsx
@@ -1,24 +1,29 @@
-import React, { useState } from 'react';
+import React from 'react';
 import DatePicker, { registerLocale } from 'react-datepicker';
 import ko from 'date-fns/locale/ko';
 import { getMonth, getYear } from 'date-fns';
 import 'react-datepicker/dist/react-datepicker.css';
 import '@styles/Main/customMiniCalendar.css';
 
+import { useAppDispatch, useAppSelector } from '@hooks/reduxWithType';
+import { changeViewDate } from '@features/mainSlice';
+
 import { BiChevronRight, BiChevronLeft } from 'react-icons/bi';
 
 import Spacing from '@component/common/Spacing';
 
-registerLocale("ko", ko);
+import { getViewDateObj, getMomentFromViewDate, getDateFromViewDate } from "@utils/formattingDate";
 
-interface ICustomHeader {
+registerLocale("ko", ko);
+export interface ICustomHeader {
     date: Date;
     decreaseMonth: () => void;
     increaseMonth: () => void;
 }
 
 function MiniCalendar () {
-    const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
+    const { viewDate } = useAppSelector((state) => state.main);
+    const dispatch = useAppDispatch();
 
     const CustomHeader = ({date, decreaseMonth, increaseMonth}: ICustomHeader) => {
         return (
@@ -26,13 +31,25 @@ function MiniCalendar () {
                 <div className='flex'>
                     <span>{`${getYear(date)}년`}</span>
                     <Spacing space='mr-1'/>
-                    <span>{`${getMonth(date)}월`}</span>
+                    <span>{`${getMonth(date) + 1}월`}</span>
                 </div>
                 <div>
-                    <button type='button' onClick={decreaseMonth}>
+                    <button type='button' onClick={() => {
+                        decreaseMonth();
+
+                        const momentDate = getMomentFromViewDate(viewDate);
+                        const prevMonth = momentDate.subtract(1, 'month').startOf('month').format();
+                        dispatch(changeViewDate(getViewDateObj(prevMonth)));
+                    }}>
                         <BiChevronLeft size="1.2rem" color='#53535a' />
                     </button>
-                    <button type='button' onClick={increaseMonth}>
+                    <button type='button' onClick={() => {
+                        increaseMonth();
+
+                        const momentDate = getMomentFromViewDate(viewDate);
+                        const nextMonth = momentDate.add(1, 'month').startOf('month').format();
+                        dispatch(changeViewDate(getViewDateObj(nextMonth)));
+                    }}>
                         <BiChevronRight size="1.2rem" color='#53535a' />
                     </button>
                 </div>
@@ -43,11 +60,15 @@ function MiniCalendar () {
     return (
       <div className='flex justify-center items-center py-2'>
         <DatePicker
-            dateFormat='yyyy.MM.dd' // 날짜 형태
             locale="ko" // 달력 표시 언어
             shouldCloseOnSelect={false} // 날짜를 선택하면 datepicker가 자동으로 닫히게 할지 여부
-            selected={selectedDate} // 선택된 날짜 type: Date
-            onChange={(date) => setSelectedDate(date)} // 다른 날짜 클릭 시 날짜 변하게 하는 이벤트 핸들러
+            selected={getDateFromViewDate(viewDate)} // 선택된 날짜 type: Date
+            onChange={(date) => {
+                if (date) {
+                    const temp = getViewDateObj(date.toISOString());
+                    dispatch(changeViewDate(temp));
+                }
+            }} // 다른 날짜 클릭 시 날짜 변하게 하는 이벤트 핸들러
             inline // input을 클릭하여 달력을 띄우는 것이 아닌 달력만 보이도록 하는 속성
             renderCustomHeader={({ date, decreaseMonth, increaseMonth }) => ( // *년 *월 부분의 Header를 커스텀하게 
                 <CustomHeader

--- a/src/component/Main/MiniCalendar.tsx
+++ b/src/component/Main/MiniCalendar.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import DatePicker, { registerLocale } from 'react-datepicker';
+import ko from 'date-fns/locale/ko';
+import { getMonth, getYear } from 'date-fns';
+import 'react-datepicker/dist/react-datepicker.css';
+import '@styles/Main/customMiniCalendar.css';
+
+import { BiChevronRight, BiChevronLeft } from 'react-icons/bi';
+
+import Spacing from '@component/common/Spacing';
+
+registerLocale("ko", ko);
+
+interface ICustomHeader {
+    date: Date;
+    decreaseMonth: () => void;
+    increaseMonth: () => void;
+}
+
+function MiniCalendar () {
+    const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
+
+    const CustomHeader = ({date, decreaseMonth, increaseMonth}: ICustomHeader) => {
+        return (
+            <div className='flex justify-between px-2 font-sans'>
+                <div className='flex'>
+                    <span>{`${getYear(date)}년`}</span>
+                    <Spacing space='mr-1'/>
+                    <span>{`${getMonth(date)}월`}</span>
+                </div>
+                <div>
+                    <button type='button' onClick={decreaseMonth}>
+                        <BiChevronLeft size="1.2rem" color='#53535a' />
+                    </button>
+                    <button type='button' onClick={increaseMonth}>
+                        <BiChevronRight size="1.2rem" color='#53535a' />
+                    </button>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+      <div className='flex justify-center items-center py-2'>
+        <DatePicker
+            dateFormat='yyyy.MM.dd' // 날짜 형태
+            locale="ko" // 달력 표시 언어
+            shouldCloseOnSelect={false} // 날짜를 선택하면 datepicker가 자동으로 닫히게 할지 여부
+            selected={selectedDate} // 선택된 날짜 type: Date
+            onChange={(date) => setSelectedDate(date)} // 다른 날짜 클릭 시 날짜 변하게 하는 이벤트 핸들러
+            inline // input을 클릭하여 달력을 띄우는 것이 아닌 달력만 보이도록 하는 속성
+            renderCustomHeader={({ date, decreaseMonth, increaseMonth }) => ( // *년 *월 부분의 Header를 커스텀하게 
+                <CustomHeader
+                    date={date}
+                    decreaseMonth={decreaseMonth}
+                    increaseMonth={increaseMonth}
+                />
+              )}
+        />
+      </div>
+    );
+}
+
+export default MiniCalendar;

--- a/src/component/Main/Sidebar.tsx
+++ b/src/component/Main/Sidebar.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import { GoTriangleDown } from 'react-icons/go';
+
+import Plus from "@asset/plus.svg";
+import MiniCalendar from "./MiniCalendar";
+
+function Sidebar() {
+    return (
+        <div className="w-64 h-full px-2 border-r">
+            <div className="h-17 py-2">
+                <button
+                    className="flex justify-between items-center w-36 h-12 px-4 border rounded-3xl shadow-md shadow-slate-400"
+                >
+                    <div className="pr-3">
+                        <img src={Plus} alt="" />
+                    </div>
+                    <span className="text-sm">만들기</span>
+                    <GoTriangleDown color="#62676b" />
+                </button>
+            </div>
+            <MiniCalendar />
+        </div>
+    )
+}
+
+export default Sidebar;

--- a/src/component/common/Spacing.tsx
+++ b/src/component/common/Spacing.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+/**
+ * 컴포넌트 간 margin을 명확히 표현하기 위한 컴포넌트
+ * @param space margin 관련 tailwindcss
+ * @returns 마진 크기만큼의 div
+ */
+function Spacing({space}: {space: string}) {
+    return (
+        <div className={`w-0 h-full ${space}`}></div>
+    )
+}
+
+export default Spacing;

--- a/src/container/Calendar.tsx
+++ b/src/container/Calendar.tsx
@@ -1,9 +1,0 @@
-function Calendar () {
-    return (
-        <>
-            <h1 className="text-3xl font-bold underline">Hello world!</h1>
-        </>
-    )
-}
-
-export default Calendar;

--- a/src/container/ErrorPage.tsx
+++ b/src/container/ErrorPage.tsx
@@ -16,7 +16,9 @@ function ErrorPage() {
       <h1>Oops!</h1>
       <p>Sorry, an unexpected error has occurred.</p>
       <p>
-        <i>{e.statusText || e.error.message}</i>
+        {e.error ? (
+          <i>{e.statusText || e.error.message}</i>
+        ) : null}
       </p>
     </div>
   );

--- a/src/container/Main.tsx
+++ b/src/container/Main.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import Gnb from "@component/Main/Gnb";
 import Sidebar from "@component/Main/Sidebar";
+import Aside from "@component/Main/Aside";
 
 function Main() {
     return (
@@ -10,6 +11,7 @@ function Main() {
             <Gnb />
             <div className="flex-1 flex w-full">
                 <Sidebar />
+                <Aside />
             </div>
         </div>
     )

--- a/src/container/Main.tsx
+++ b/src/container/Main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+
+
+function Main() {
+    return (
+        <div className="box-border font-sans text-primary w-screen h-screen flex flex-col">
+            
+        </div>
+    )
+}
+
+export default Main;

--- a/src/container/Main.tsx
+++ b/src/container/Main.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 
 
+import Gnb from "@component/Main/Gnb";
 
 function Main() {
     return (
         <div className="box-border font-sans text-primary w-screen h-screen flex flex-col">
-            
+            <Gnb />
         </div>
     )
 }

--- a/src/container/Main.tsx
+++ b/src/container/Main.tsx
@@ -2,11 +2,15 @@ import React from "react";
 
 
 import Gnb from "@component/Main/Gnb";
+import Sidebar from "@component/Main/Sidebar";
 
 function Main() {
     return (
         <div className="box-border font-sans text-primary w-screen h-screen flex flex-col">
             <Gnb />
+            <div className="flex-1 flex w-full">
+                <Sidebar />
+            </div>
         </div>
     )
 }

--- a/src/container/Main.tsx
+++ b/src/container/Main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { Outlet } from "react-router-dom";
 
 import Gnb from "@component/Main/Gnb";
 import Sidebar from "@component/Main/Sidebar";
@@ -11,6 +12,9 @@ function Main() {
             <Gnb />
             <div className="flex-1 flex w-full">
                 <Sidebar />
+                <div className="flex-1 h-full">
+                    <Outlet />
+                </div>
                 <Aside />
             </div>
         </div>

--- a/src/container/Main.tsx
+++ b/src/container/Main.tsx
@@ -1,4 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
+
+import { useParams, useNavigate } from "react-router-dom";
+
+import { useAppDispatch, useAppSelector } from '@hooks/reduxWithType';
+import { changeViewDate, changeDrilldownView } from "@/features/mainSlice";
 
 import { Outlet } from "react-router-dom";
 
@@ -6,7 +11,56 @@ import Gnb from "@component/Main/Gnb";
 import Sidebar from "@component/Main/Sidebar";
 import Aside from "@component/Main/Aside";
 
+import { getViewDateObj, isDiffBetweenViewDateAndPathDate } from "@/utils/formattingDate";
+
+import moment from "moment";
+
 function Main() {
+    const { viewDate, drilldownView } = useAppSelector((state) => state.main);
+    const dispatch = useAppDispatch();
+
+    const navigate = useNavigate();
+    const params = useParams();
+    const pathDate = { year: params.year || '', month: params.month || '', date: params.date || '' };
+
+    useEffect(() => {
+        // Case 1. url이 수정되는 경우
+        // Case 1 - 1. url 을 정상적으로 입력하지 않은 경우 -> 오늘 날짜로 수정 및 이동
+        if (!params.drilldownView || !params.year || !params.month || !params.date) {
+            const today = moment().format();
+            const temp = getViewDateObj(today);
+
+            dispatch(changeDrilldownView('month'));
+            dispatch(changeViewDate(temp));
+            return;
+        }
+
+        // Case 1 - 2. url이 기존과 동일할 경우 -> 수정 필요 없음
+        if (drilldownView === params.drilldownView && !isDiffBetweenViewDateAndPathDate(viewDate, pathDate)) {
+            return;
+        }
+
+        // Case 1 - 3. url에서 drilldownView 부분이 다른 경우 -> state 수정
+        if (drilldownView !== params.drilldownView 
+            && (params.drilldownView === 'month' 
+                || params.drilldownView === 'week'
+                || params.drilldownView === 'day')
+            ) {
+            dispatch(changeDrilldownView(drilldownView));
+        }
+
+        // Case 1 - 4. url에서 날짜 부분이 다른 경우 -> state 수정
+        if (isDiffBetweenViewDateAndPathDate(viewDate, pathDate)) {
+            dispatch(changeViewDate({ year: pathDate.year, month: pathDate.month, date: pathDate.date }));
+        }
+
+    }, [drilldownView, params.year, params.month, params.pathDate])
+
+    useEffect(() => {
+        // Case 2. state를 수정하는 경우
+        navigate(`${drilldownView}/${viewDate.year}/${viewDate.month}/${viewDate.date}`);
+    }, [drilldownView, viewDate.year, viewDate.month, viewDate.date])
+
     return (
         <div className="box-border font-sans text-primary w-screen h-screen flex flex-col">
             <Gnb />

--- a/src/features/mainSlice.ts
+++ b/src/features/mainSlice.ts
@@ -1,0 +1,38 @@
+import moment from 'moment';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type IViewDate = {
+    year: string;
+    month: string;
+    date: string;
+}
+type IDrilldownView = 'month' | 'week' | 'work_week' | 'day' | 'agenda';
+interface MainState {
+    viewDate: IViewDate;
+    drilldownView: IDrilldownView | null | undefined;
+}
+
+const initialState: MainState = {
+    viewDate: {
+        year: '',
+        month: '',
+        date: '',        
+    },
+    drilldownView: 'month',
+}
+
+const mainSlice = createSlice({
+    name: 'main',
+    initialState,
+    reducers: {
+        changeViewDate(state, action: PayloadAction<IViewDate>) {
+            state.viewDate = action.payload;
+        },
+        changeDrilldownView(state, action: PayloadAction<IDrilldownView | null | undefined>) {
+            state.drilldownView = action.payload;
+        }
+    }
+})
+
+export const { changeViewDate, changeDrilldownView } = mainSlice.actions;
+export default mainSlice.reducer;

--- a/src/hooks/reduxWithType.ts
+++ b/src/hooks/reduxWithType.ts
@@ -1,0 +1,10 @@
+import {
+	TypedUseSelectorHook,
+  	useDispatch,
+  	useSelector
+} from 'react-redux';
+import { RootState, AppDispatch } from '@/store';
+
+// useSelector 함수를 타입과 함께 alias 한 것
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import mainReducer from './features/mainSlice';
+
+export const store = configureStore({
+	reducer: {
+      main: mainReducer,
+    }
+});
+
+export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof store.getState>;

--- a/src/styles/Main/customMainCalendar.css
+++ b/src/styles/Main/customMainCalendar.css
@@ -36,6 +36,13 @@
                         justify-content: center;
                         align-items: center;
                     }
+
+                    .rbc-row-segment {
+                        .rbc-event {
+                            padding: 0;
+                            background-color: transparent;
+                        }
+                    }
                 }
             }
         }

--- a/src/styles/Main/customMainCalendar.css
+++ b/src/styles/Main/customMainCalendar.css
@@ -1,0 +1,43 @@
+.rbc-calendar {
+    height: 100% !important;
+
+    .rbc-toolbar {
+        display: none;
+    }
+
+    .rbc-month-view {
+        border: none;
+
+        .rbc-month-header {
+            border: none;
+            padding: 4px 0;
+
+            .rbc-header {
+                border: none;
+            }
+
+            .rbc-header > p {
+                font-size: 11px;
+            }
+        }
+
+        .rbc-month-row {
+            border-top: none;
+            border-left: none;
+            border-right: none;
+            border-bottom: 1px solid #e5e7eb;
+            
+            .rbc-row-content {
+                padding: 4px 0;
+
+                .rbc-row {
+                    .rbc-current {
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/styles/Main/customMiniCalendar.css
+++ b/src/styles/Main/customMiniCalendar.css
@@ -1,0 +1,52 @@
+.react-datepicker {
+    font-family: 'Roboto', 'Noto Sans KR', serif;
+    border: none;
+    border-radius: 0;
+
+    .react-datepicker__header {
+      background-color: #ffffff;
+      border-bottom: none;
+      border-radius: 0;
+
+      .react-datepicker__day-names {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 1.4rem;
+
+        .react-datepicker__day-name {
+            width: 1.4rem;
+            height: 1.4rem;
+            line-height: 1.4rem;
+            font-size: 10px;
+            color: #5b5b5b;
+        }
+      }
+    }
+
+    .react-datepicker__triangle {
+      display: none;
+    }
+
+    .react-datepicker__month {
+        margin: 0;
+        .react-datepicker__day {
+            width: 1.4rem;
+            height: 1.4rem;
+            line-height: 1.4rem;
+            font-size: 10px;
+            color: #454545;
+        }
+
+        .react-datepicker__day--outside-month {
+            color: #686868;
+        }
+
+        .react-datepicker__day--selected {
+            border-radius: 50px;
+            background-color: #1D73E8;
+            color: #ffffff;
+            font-weight: 400;
+        }
+    }
+}

--- a/src/utils/formattingDate.ts
+++ b/src/utils/formattingDate.ts
@@ -1,0 +1,104 @@
+import moment from "moment";
+
+/**
+ * Main Calendar에서 각 이벤트 시작 날짜 string을 만드는 함수
+ * @param {Date | undefined} date 이벤트 시작 날짜
+ * @returns {string} 오전 6시 또는 오후 6:30 등의 형태
+ */
+export const formattingTime = (date: Date | undefined): string => {
+    if (!date) {
+        return '';
+    }
+
+    let time = '';
+
+    const hour = date.getHours();
+    const minute = date.getMinutes();
+
+    if (hour - 12 < 0) {
+        time += `오전 ${hour}`
+    } else {
+        time += `오후 ${hour - 12}`
+    }
+
+    if (minute === 0) {
+        time += `시 `
+    } else {
+        time += `:${minute} `
+    }
+
+    return time;
+}
+
+/**
+ * Main Calendar에서 이벤트 시작 날짜와 끝나는 날짜가 같은지 다른지를 반환하는 함수
+ * @param {Date | undefined} start 이벤트 시작 날짜
+ * @param {Date | undefined} end 이벤트 마무리 날짜
+ * @returns {boolean}  이벤트 시작 날짜와 끝나는 날짜가 같은지 다른지 여부
+ */
+export const isAnotherDate = (start: Date | undefined, end: Date | undefined): boolean => {
+    if (!start || !end) {
+        return false;
+    }
+
+    const startDate = start.getDate();
+    const endDate = end.getDate();
+
+    return startDate !== endDate;
+}
+
+type IViewDate = { year: string, month: string, date: string };
+/**
+ * 전역적으로 사용할 date().format()을 { year, month, date } 형태로 바꿔 반환하는 함수
+ * @param {string} date moment().format() 형태의 string
+ * @returns main state의 viewDate 형태
+ */
+export const getViewDateObj = (isoDate: string): IViewDate => {
+    let temp = moment(isoDate);
+
+    const year = temp.year().toString();
+    const month = (temp.month() + 1).toString();
+    const date = temp.date().toString();
+
+    return { year, month, date };
+}
+
+/**
+ * 전역적으로 사용할 { year, month, date } 를 moment 타입으로 바꿔 반환하는 함수
+ * @param viewDate main state의 viewDate 형태
+ * @returns Moment 객체
+ */
+export const getMomentFromViewDate = (viewDate: IViewDate): moment.Moment => {
+    const { year, month, date } = viewDate;
+
+    return moment(`${year}-${month}-${date}`);
+}
+
+/**
+ * 전역적으로 사용할 { year, month, date } 를 moment 타입으로 바꿔 반환하는 함수
+ * @param viewDate main state의 viewDate 형태
+ * @returns Date 객체
+ */
+export const getDateFromViewDate = (viewDate: IViewDate): Date => {
+    const { year, month, date } = viewDate;
+
+    if (!year || !month || !date) {
+        return new Date();
+    }
+
+    return new Date(`${year}-${month}-${date}`);
+}
+
+/**
+ * 전역적으로 사용할 url pathDate와 staet의 viewDate가 같은지 다른지 여부를 반환하는 함수
+ * @param viewDate main state의 viewDate
+ * @param pathDate url 의 pathDate
+ * @returns {boolean}
+ */
+export const isDiffBetweenViewDateAndPathDate = (viewDate: IViewDate, pathDate: IViewDate): boolean => {
+    return (
+        viewDate.year !== pathDate.year 
+        || viewDate.month !== pathDate.month 
+        || viewDate.date !== pathDate.date
+    );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,12 +3,21 @@ module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}",],
   theme: {
     extend: {
+      width: {
+        '112': '28rem',
+      },
+      height: {
+        '130': '32.5rem',
+      },
       fontFamily: {
         sans: ["Noto Sans, Open Sans, sans-serif"],
       },
       colors: {
         primary: "#3C4043",
-        selected: "#1D73E8"
+        selected: "#1D73E8",
+        first: "#4598DF",
+        second: "#C2CA51",
+        tertiary: "#377745",
       }
     },
     screens: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,11 @@
       "@asset/*": ["src/asset/*"],
       "@component/*": ["src/component/*"],
       "@container/*": ["src/container/*"],
+      "@features/*": ["src/features/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@routes/*": ["src/routes/*"],
       "@styles/*": ["src/styles/*"],
+      "@utils/*": ["src/utils/*"],
     },
     "lib": [
       "dom",


### PR DESCRIPTION
프로젝트 세팅에 redux와 캘린더 라이브러리를 추가하였습니다.
- React + React hook
- typescript
- 상태관리: reduxjs/toolkit, react-redux
- 캘린더: react-datepicker, react-big-calendar

[calendar 라이브러리 관련 설정 및 공부 내용 블로깅](https://velog.io/@kay_/%EA%B5%AC%EA%B8%80-%EC%BA%98%EB%A6%B0%EB%8D%94-%ED%81%B4%EB%A1%A0%EC%BD%94%EB%94%A94-%EC%BA%98%EB%A6%B0%EB%8D%94-%EB%9D%BC%EC%9D%B4%EB%B8%8C%EB%9F%AC%EB%A6%AC)
- 요약
  - react-datepicker라는 라이브러리의 CSS를 커스텀하게 변경하려면 기존 class를 찾아 그 스타일을 덮어씌우는 형태로 작성
  - 작은 달력, 큰 달력 상관없이 같은 CSS가 적용되게 되었고, 따라서 달력 라이브러리를 두개로 나누어 사용하였습니다.

[reduxjs/toolkit, react-redux 관련 설정 및 공부 내용 블로깅](https://velog.io/@kay_/SEBFE45-2023.06.23-React-%EC%83%81%ED%83%9C%EA%B4%80%EB%A6%AC-Redux)
[+ 이슈 해결](https://velog.io/@kay_/%EA%B5%AC%EA%B8%80-%EC%BA%98%EB%A6%B0%EB%8D%94-%ED%81%B4%EB%A1%A0%EC%BD%94%EB%94%A95-%EC%83%81%ED%83%9C%EA%B4%80%EB%A6%AC-Redux)
- 요약
  - redux 운영자가 제안하는 typescript을 사용하여 react-redux, reduxjs/toolkit을 다루는 코드에 대해 학습하고 적용해보았습니다.
  - state 관리에 대한 나름의 규칙을 세워 코드를 수정하였습니다.